### PR TITLE
Пофиксить возможность отправки отчёта незарегистрированным пользователем

### DIFF
--- a/src/main/java/com/example/petshelterg2/constants/Constants.java
+++ b/src/main/java/com/example/petshelterg2/constants/Constants.java
@@ -530,5 +530,6 @@ public class Constants {
     public final static String CONTACT_WITH_ME_BUTTON_CAT = "Оставить контактные данные" + " " + PHONE_EMOJI; // Бот может принять и записать контактные данные для связи (приют кошек)
     public final static String CONTACT_WITH_ME_BUTTON_DOG = "Oставить контактные данные" + " " + PHONE_EMOJI; // Бот может принять и записать контактные данные для связи (приют собак)
 
+    public static final String NO_NEED_TO_SEND_A_REPORT = "Вам не нужно отправлять отчёт!";
 
 }

--- a/src/main/java/com/example/petshelterg2/controller/TelegramBot.java
+++ b/src/main/java/com/example/petshelterg2/controller/TelegramBot.java
@@ -504,9 +504,14 @@ public class TelegramBot extends TelegramLongPollingBot {  //есть еще к�
     }
 
     private void shelterThirdCat(long chatId, String name) {
-        prepareAndSendMessage(chatId, SHELTER_THIRD_STEP_CAT);
-        saveSelection(chatId, false, 1);
-        log.info("Replied to user " + name);
+        Probation ownerProbation = catOwnersRepository.findById(chatId).get().getProbation();
+        if(ownerProbation.equals(Probation.IN_PROGRESS)) {
+            prepareAndSendMessage(chatId, SHELTER_THIRD_STEP_CAT);
+            saveSelection(chatId, false, 1);
+            log.info("Replied to user " + name);
+        } else {
+            prepareAndSendMessage(chatId, NO_NEED_TO_SEND_A_REPORT);
+        }
     }
 
     private void photoShelterThirdCat(long chatId, String name) {
@@ -528,9 +533,14 @@ public class TelegramBot extends TelegramLongPollingBot {  //есть еще к�
     }
 
     private void shelterThirdDog(long chatId, String name) {
-        prepareAndSendMessage(chatId, SHELTER_THIRD_STEP_DOG);
-        saveSelection(chatId, true, 1);
-        log.info("Replied to user " + name);
+        Probation ownerProbation = dogOwnersRepository.findById(chatId).get().getProbation();
+        if(ownerProbation.equals(Probation.IN_PROGRESS)){
+            prepareAndSendMessage(chatId, SHELTER_THIRD_STEP_DOG);
+            saveSelection(chatId, true, 1);
+            log.info("Replied to user " + name);
+        } else {
+            prepareAndSendMessage(chatId, NO_NEED_TO_SEND_A_REPORT);
+        }
     }
 
     private void photoShelterThirdDog(long chatId, String name) {


### PR DESCRIPTION
Теперь отчёт может отправить только пользователь у которого Probation (испытательный срок) в статусе IN_PROGRESS . Это значить что воспользоваться кнопкой смогут только те пользователи кто реально должен отправлять отчёт.